### PR TITLE
Update requirements.yml to point to cci-moc organization and use hashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ in [requirements.yml](requirements.yml). You can install them like
 this:
 
 ```
-ansible-galaxy install -r requirements.yml --role-path roles
+ansible-galaxy install -r requirements.yml --roles-path roles
 ```
 
 If `version` in a requirement is set to `master`, Ansible can't tell
@@ -17,7 +17,7 @@ when there's been an update. You can force a re-install by adding the
 `--force` option...
 
 ```
-ansible-galaxy install -r requirements.yml --role-path roles --force
+ansible-galaxy install -r requirements.yml --roles-path roles --force
 ```
 
 ...although it's better to use specific references (tags, commit ids,

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,20 +1,16 @@
 roles:
-  - name: moc_base
-    src: https://github.com/larsks/ansible-role-moc-base
-    version: master
-
-  - name: moc_firewall
-    src: https://github.com/larsks/ansible-role-moc-firewall
-    version: master
-
-  - name: moc_sshd
-    src: https://github.com/larsks/ansible-role-moc-sshd
-    version: master
-
-  - name: root_authorized_keys
-    src: https://github.com/larsks/ansible-role-root-authorized-keys
-    version: master
-
-  - name: systemd
-    src: https://github.com/larsks/ansible-role-systemd
-    version: master
+    - name: moc_base
+      src: https://github.com/cci-moc/ansible-role-moc-base
+      version: 1bae42b220
+    - name: moc_firewall
+      src: https://github.com/cci-moc/ansible-role-moc-firewall
+      version: ab2c7be182
+    - name: moc_sshd
+      src: https://github.com/cci-moc/ansible-role-moc-sshd
+      version: 3e65414e32
+    - name: root_authorized_keys
+      src: https://github.com/cci-moc/ansible-role-root-authorized-keys
+      version: 2456e46a28
+    - name: systemd
+      src: https://github.com/cci-moc/ansible-role-systemd
+      version: f0a9fea177


### PR DESCRIPTION
- Update requirements.yml to point to cci-moc, rather than my personal
  repositories.

- Use explicit hashes rather than `master` to prevent unexpected
  disruptions.
