### PR TITLE
Define fw_post_reload for auth servers

### DIFF
--- a/group_vars/auth_servers/moc_firewall.yml
+++ b/group_vars/auth_servers/moc_firewall.yml
@@ -1,4 +1,5 @@
 fw_reload_mode: live
+fw_reload_post: systemctl restart docker
 fw_enabled_services_auth:
   - ssh_moc
   - web


### PR DESCRIPTION
This will run /app/startup.sh after reloading the firewall rules,
which will restart docker and the containerized services.

Requires https://github.com/CCI-MOC/ansible-role-moc-firewall/pull/3
