### PR TITLE
Add configuration for repository mirrors

### DIFF
--- a/group_vars/mirrors/moc_firewall.yml
+++ b/group_vars/mirrors/moc_firewall.yml
@@ -1,0 +1,5 @@
+fw_reload_mode: live
+fw_enabled_services_mirrors:
+  - ssh_moc
+  - web_moc
+  - zabbix

--- a/mirror_servers.yml
+++ b/mirror_servers.yml
@@ -1,0 +1,3 @@
+- hosts: mirror_servers
+  roles:
+    - repomirror

--- a/requirements.yml
+++ b/requirements.yml
@@ -14,3 +14,12 @@ roles:
     - name: systemd
       src: https://github.com/cci-moc/ansible-role-systemd
       version: master
+    - name: repomirror
+      src: https://github.com/cci-moc/ansible-role-repomirror
+      version: master
+    - name: httpd
+      src: https://github.com/cci-moc/ansible-role-httpd
+      version: master
+    - name: podman
+      src: https://github.com/cci-moc/ansible-role-podman
+      version: master

--- a/site.yml
+++ b/site.yml
@@ -2,3 +2,4 @@
 - import_playbook: mail_servers.yml
 - import_playbook: auth_servers.yml
 - import_playbook: hil_servers.yml
+- import_playbook: mirror_servers.yml


### PR DESCRIPTION
This adds the 'mirrors' group (currently with only one member,
mochat.massopen.cloud), and applies the 'repomirror' [1] role to this
group.

Closes cci-moc/ops-issues#265

[1]: https://github.com/CCI-MOC/ansible-role-repomirror
