### PR TITLE
feature/moc control

### DIFF
--- a/control_hosts.yml
+++ b/control_hosts.yml
@@ -1,0 +1,3 @@
+- hosts: control_hosts
+  roles:
+    - moc_control

--- a/group_vars/mirrors/moc_firewall.yml
+++ b/group_vars/mirrors/moc_firewall.yml
@@ -1,0 +1,4 @@
+fw_reload_mode: live
+fw_enabled_services_mirrors:
+  - ssh_moc
+  - web_moc

--- a/mirror_servers.yml
+++ b/mirror_servers.yml
@@ -1,0 +1,3 @@
+- hosts: mirror_servers
+  roles:
+    - repomirror

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,16 +1,25 @@
 roles:
     - name: moc_base
       src: https://github.com/cci-moc/ansible-role-moc-base
-      version: 1bae42b220
+      version: master
     - name: moc_firewall
       src: https://github.com/cci-moc/ansible-role-moc-firewall
-      version: 70feb1e1c1
+      version: master
     - name: moc_sshd
       src: https://github.com/cci-moc/ansible-role-moc-sshd
-      version: 6dfc32cffa
+      version: master
     - name: root_authorized_keys
       src: https://github.com/cci-moc/ansible-role-root-authorized-keys
-      version: 2456e46a28
+      version: master
     - name: systemd
       src: https://github.com/cci-moc/ansible-role-systemd
-      version: f0a9fea177
+      version: master
+    - name: repomirror
+      src: https://github.com/cci-moc/ansible-role-repomirror
+      version: master
+    - name: httpd
+      src: https://github.com/cci-moc/ansible-role-httpd
+      version: master
+    - name: podman
+      src: https://github.com/cci-moc/ansible-role-podman
+      version: master

--- a/requirements.yml
+++ b/requirements.yml
@@ -23,3 +23,6 @@ roles:
     - name: podman
       src: https://github.com/cci-moc/ansible-role-podman
       version: master
+    - name: moc_control
+      src: https://github.com/cci-moc/ansible-role-moc-control
+      version: master

--- a/site.yml
+++ b/site.yml
@@ -2,3 +2,4 @@
 - import_playbook: mail_servers.yml
 - import_playbook: auth_servers.yml
 - import_playbook: hil_servers.yml
+- import_playbook: mirror_servers.yml

--- a/site.yml
+++ b/site.yml
@@ -1,4 +1,5 @@
 - import_playbook: common.yml
+- import_playbook: control_hosts.yml
 - import_playbook: mail_servers.yml
 - import_playbook: auth_servers.yml
 - import_playbook: hil_servers.yml

--- a/update.yml
+++ b/update.yml
@@ -1,0 +1,26 @@
+- hosts: localhost
+  vars:
+    moc_inventory_repo: https://github.com/cci-moc/moc-inventory-prod
+    moc_inventory_version: master
+    moc_playbooks_repo: https://github.com/cci-moc/moc-ansible-infra
+    moc_playbooks_version: master
+  tasks:
+    - name: check out inventory
+      git:
+        repo: "{{ moc_inventory_repo }}"
+        dest: "{{ ansible_user_dir }}/inventory"
+        version: "{{ moc_inventory_version }}"
+        force: true
+
+    - name: check out playbooks
+      git:
+        repo: "{{ moc_playbooks_repo }}"
+        dest: "{{ ansible_user_dir }}/playbooks"
+        version: "{{ moc_playbooks_version }}"
+        force: true
+
+    - name: install roles
+      command: >-
+        ansible-galaxy role install -r requirements.yml -p roles -f
+      args:
+        chdir: "{{ ansible_user_dir }}/playbooks"


### PR DESCRIPTION
Add playbooks for managing ansible control host

Add playbooks that use the moc_control [1] role to configure an
ansible control host. This ensures that our inventory and playbook
repositories are checked at out in the correct location and arranges
for periodic (hourly) execution of the main `site.yml` playbook.

[1]: https://github.com/CCI-MOC/ansible-role-moc-control

