### PR TITLE
Add `web_moc` rule to mirror_servers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 .facts/
 roles/
 collections/
+moc-inventory-prod/

--- a/group_vars/mirror_servers/moc_firewall.yml
+++ b/group_vars/mirror_servers/moc_firewall.yml
@@ -1,0 +1,2 @@
+fw_enabled_services_mirror_servers:
+  - web_moc

--- a/mirror_servers.yml
+++ b/mirror_servers.yml
@@ -1,0 +1,1 @@
+- hosts: mirror_servers

--- a/site.yml
+++ b/site.yml
@@ -2,3 +2,4 @@
 - import_playbook: mail_servers.yml
 - import_playbook: auth_servers.yml
 - import_playbook: hil_servers.yml
+- import_playbook: mirror_servers.yml


### PR DESCRIPTION
this allows hosts on moc networks to access port 80 and 443 on our repo server

and also a quick change to gitignore.