### PR TITLE
Add mailman role to ansible configuration

### DIFF
--- a/group_vars/mail_servers/mailman.yml
+++ b/group_vars/mail_servers/mailman.yml
@@ -1,0 +1,4 @@
+mailman_prune_lists:
+  - rootmail
+  - cephalerts
+  - alerts

--- a/mail_servers.yml
+++ b/mail_servers.yml
@@ -1,1 +1,3 @@
 - hosts: mail_servers
+  roles:
+    - mailman

--- a/requirements.yml
+++ b/requirements.yml
@@ -23,3 +23,6 @@ roles:
     - name: podman
       src: https://github.com/cci-moc/ansible-role-podman
       version: master
+    - name: mailman
+      src: https://github.com/cci-moc/ansible-role-mailman
+      version: master


### PR DESCRIPTION
The mailman role is currently responsible for setting up the
automatically expiring messages from specific mailing lists.

Closes cci-moc/ops-issues#418
